### PR TITLE
Fix runtime error by using the current runner

### DIFF
--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -1,6 +1,8 @@
-module Main exposing (..)
+port module Main exposing (..)
 
 import Legacy.ElmTest as ElmTest exposing (..)
+import Test.Runner.Node exposing (run, TestProgram)
+import Json.Encode exposing (Value)
 
 
 allTests : Test
@@ -9,5 +11,9 @@ allTests =
         [ equals 1 1 ]
 
 
+main : TestProgram
 main =
-    ElmTest.runSuite allTests
+    run emit allTests
+
+
+port emit : ( String, Value ) -> Cmd msg

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -9,7 +9,14 @@
     "exposed-modules": [],
     "dependencies": {
         "rtfeldman/legacy-elm-test": "3.0.0 <= v < 4.0.0",
-        "elm-lang/core": "5.0.0 <= v < 6.0.0"
+        "elm-community/elm-test": "3.1.0 <= v < 4.0.0",
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-community/json-extra": "2.0.0 <= v < 3.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0",
+        "mgold/elm-random-pcg": "4.0.2 <= v < 5.0.0",
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-community/elm-test": "3.0.0 <= v < 4.0.0",
+        "rtfeldman/node-test-runner": "3.0.0 <= v < 4.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }


### PR DESCRIPTION
This come from adapting the [code](https://github.com/rtfeldman/node-test-runner/blob/master/templates/Main.elm) that `elm-test init` will insert on its own.